### PR TITLE
Enable I2C2 bus of auav x21

### DIFF
--- a/src/drivers/boards/auav-x21/board_config.h
+++ b/src/drivers/boards/auav-x21/board_config.h
@@ -109,8 +109,9 @@
 
 /* I2C busses */
 
-/* There is no I2C2 so there is not notion of internal / external*/
-#define PX4_I2C_BUS_EXPANSION 1
+/* I2C busses */
+#define PX4_I2C_BUS_EXPANSION 	1
+#define PX4_I2C_BUS_ONBOARD	2
 #define PX4_I2C_BUS_LED		PX4_I2C_BUS_EXPANSION
 
 /* Devices not on the onboard bus.


### PR DESCRIPTION
Enable the I2C2 bus of auav x2.1. This change came after a MAG registering 3 times on the I2C bus due to messed initialization script on the x21 board.

We slightly moded the board so we could use the I2C2 bus but now there was no initialization of the bus.